### PR TITLE
[SYNTH-13711] Make Xcode step run on a Xcode stack

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -41,7 +41,7 @@ workflows:
     steps:
     - activate-ssh-key@4: {}
     - git-clone@8: {}
-    - path::./Users/vagrant/git:
+    - path::/Users/vagrant/git:
         inputs:
         - api_key: $DATADOG_API_KEY
         - app_key: $DATADOG_APP_KEY

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -21,6 +21,11 @@ stages:
     - test-on-Ubuntu-stack: {}
     - test-on-Xcode-stack: {}
 
+meta:
+  bitrise.io:
+    stack: linux-docker-android-20.04
+    machine_type_id: standard
+
 workflows:
   test-on-Ubuntu-stack:
     steps:
@@ -36,11 +41,15 @@ workflows:
     steps:
     - activate-ssh-key@4: {}
     - git-clone@8: {}
-    - path::./:
+    - path::./Users/vagrant/git:
         inputs:
         - api_key: $DATADOG_API_KEY
         - app_key: $DATADOG_APP_KEY
         - public_ids: "7uk-gte-ywv"
+    meta:
+      bitrise.io:
+        stack: osx-xcode-edge
+        machine_type_id: g2-m1.4core
 
   # ----------------------------------------------------------------
   # --- workflows to Share this step into a Step Library

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -38,6 +38,10 @@ workflows:
         - public_ids: "7uk-gte-ywv"
 
   test-on-Xcode-stack:
+    meta:
+      bitrise.io:
+        stack: osx-xcode-edge
+        machine_type_id: g2-m1.4core
     steps:
     - activate-ssh-key@4: {}
     - git-clone@8: {}
@@ -46,10 +50,6 @@ workflows:
         - api_key: $DATADOG_API_KEY
         - app_key: $DATADOG_APP_KEY
         - public_ids: "7uk-gte-ywv"
-    meta:
-      bitrise.io:
-        stack: osx-xcode-edge
-        machine_type_id: g2-m1.4core
 
   # ----------------------------------------------------------------
   # --- workflows to Share this step into a Step Library


### PR DESCRIPTION
This PR will make the workflow called test-on-Xcode-stack actually run on an Xcode stack in Bitrise instead of the default Ubuntu one

<img width="948" alt="image" src="https://github.com/DataDog/synthetics-test-automation-bitrise-step-run-tests/assets/25252536/1eb9d826-da15-4787-820c-75a6ab9a6816">

Note: Most of the trial and error to get this right originally happened on this PR - https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application/pull/23