### PR TITLE
Clean up `share-this-step` workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,26 +24,7 @@ To get started:
 2. Add your API and application keys to your [secrets in Bitrise][4].
 3. [Configure your step inputs][5]. You can also configure them in your `bitrise.yml` file. The only required inputs are the two secrets you configured earlier. For a comprehensive list of inputs, see the [Inputs section](#inputs).
 
-## How to use this step locally
-
-You can run this step directly using the [Bitrise CLI][6].
-
-To run this step locally:
-
-1. Open your terminal or command line.
-2. `git clone` the [Bitrise repository][6].
-3. `cd` into the directory of the step (the one you just `git clone`d).
-4. Create a `.bitrise.secrets.yml` file in the same directory of `bitrise.yml`. The `.bitrise.secrets.yml` file is a Git-ignored file, so you can store your secrets in it.
-5. Check the `bitrise.yml` file for any secret you should set in `.bitrise.secrets.yml`.
-6. Once you have the required secret parameters in your `.bitrise.secrets.yml` file, run this step with the [Bitrise CLI][6]: `bitrise run test`.
-
-An example `.bitrise.secrets.yml` file:
-
-```yml
-envs:
-- A_SECRET_PARAM_ONE: the value for secret one
-- A_SECRET_PARAM_TWO: the value for secret two
-```
+When running the step locally with the Bitrise CLI, the secrets should be stored in a `.bitrise.secrets.yml` file. See [Managing secrets locally][6].
 
 ## Simple usage
 
@@ -180,7 +161,7 @@ Additional helpful documentation, links, and articles:
 [3]: https://devcenter.bitrise.io/en/steps-and-workflows/introduction-to-steps/adding-steps-to-a-workflow.html#adding-steps-from-alternative-sources
 [4]: https://devcenter.bitrise.io/en/builds/secrets.html#setting-a-secret
 [5]: https://devcenter.bitrise.io/en/steps-and-workflows/introduction-to-steps/step-inputs.html
-[6]: https://github.com/bitrise-io/bitrise
+[6]: https://devcenter.bitrise.io/en/bitrise-cli/managing-secrets-locally.html
 [7]: https://docs.datadoghq.com/continuous_testing/cicd_integrations/configuration/?tab=npm#test-files
 [9]: https://docs.datadoghq.com/account_management/api-app-keys/
 [10]: https://docs.datadoghq.com/continuous_testing/cicd_integrations/configuration/?tab=npm#global-configuration-file

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,13 +1,6 @@
 format_version: '4'
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
-app:
-  envs:
-    - BITRISE_STEP_ID: datadog-mobile-app-run-tests
-    - BITRISE_STEP_VERSION: '1.0.1'
-    - BITRISE_STEP_GIT_CLONE_URL: https://github.com/DataDog/synthetics-test-automation-bitrise-step-run-tests.git
-    - MY_STEPLIB_REPO_FORK_GIT_URL: $MY_STEPLIB_REPO_FORK_GIT_URL
-
 trigger_map:
   - push_branch: '*'
     pipeline: test-on-Ubuntu-and-Xcode-stacks
@@ -54,8 +47,6 @@ workflows:
             - app_key: $DATADOG_APP_KEY
             - public_ids: '7uk-gte-ywv'
 
-  # ----------------------------------------------------------------
-  # --- workflows to Share this step into a Step Library
   audit-this-step:
     steps:
       - script:
@@ -64,42 +55,3 @@ workflows:
                 #!/bin/bash
                 set -ex
                 stepman audit --step-yml ./step.yml
-
-  share-this-step:
-    envs:
-      - MY_STEPLIB_REPO_FORK_GIT_URL: $MY_STEPLIB_REPO_FORK_GIT_URL
-      - BITRISE_STEP_ID: $BITRISE_STEP_ID
-      - BITRISE_STEP_VERSION: $BITRISE_STEP_VERSION
-      - BITRISE_STEP_GIT_CLONE_URL: $BITRISE_STEP_GIT_CLONE_URL
-    description: |-
-      If this is the first time you try to share a Step you should
-      first call: $ bitrise share
-
-      This will print you a guide, and information about how Step sharing
-      works. Please read it at least once!
-
-      As noted in the Step sharing guide you'll have to fork the
-      StepLib you want to share this step into. Once you're done with forking
-      the repository you should set your own fork's git clone URL
-      in the `.bitrise.secrets.yml` file, or here in the `envs` section,
-      as the value of the `MY_STEPLIB_REPO_FORK_GIT_URL` environment.
-
-      You're now ready to share this Step, just make sure that
-      the `BITRISE_STEP_ID` and `BITRISE_STEP_VERSION`
-      environments are set to the desired values!
-
-      To share this Step into a StepLib you can just run: $ bitrise run share-this-step
-
-      Once it finishes the only thing left is to actually create a Pull Request,
-      the way described in the guide printed at the end of the process.
-    before_run:
-      - audit-this-step
-    steps:
-      - script:
-          inputs:
-            - content: |-
-                #!/bin/bash
-                set -ex
-                bitrise share start -c "${MY_STEPLIB_REPO_FORK_GIT_URL}"
-                bitrise share create --stepid "${BITRISE_STEP_ID}" --tag "${BITRISE_STEP_VERSION}" --git "${BITRISE_STEP_GIT_CLONE_URL}"
-                bitrise share finish

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,6 +1,10 @@
 format_version: '4'
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
+app:
+  envs:
+    - FORCE_COLOR: 1
+
 trigger_map:
   - push_branch: '*'
     pipeline: test-on-Ubuntu-and-Xcode-stacks


### PR DESCRIPTION
This PR removes the `share-this-step` workflow because we don't share the step on the Bitrise steplib anymore.